### PR TITLE
Feature/add custom comment on failing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ def test_sum():
 
 You may pass as much listeners as you want to get report messages to all listeners.
 
+#### SlackListener
+SlackListener constructor takes **required**: `token, chat` and **optional**:  `on_error_add` fields.
+- `token` - slack token
+- `chat` - slack chat id
+- `on_error_add`[Optional] - takes string which will be added after failed or skipped test function name in main thread.
+ Is nice for tagging responsible person if required or add any custom comment.
+
+
 
 ### Launch
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You may pass as much listeners as you want to get report messages to all listene
 SlackListener constructor takes **required**: `token, chat` and **optional**:  `on_error_add` fields.
 - `token` - slack token
 - `chat` - slack chat id
-- `on_error_add`[Optional] - takes string which will be added after failed or skipped test function name in main thread.
+- `on_error_add`_[Optional]_ - takes string which will be added after failed or skipped test function name in main thread.
  Is nice for tagging responsible person if required or add any custom comment.
 
 

--- a/pytest_message/listeners/slack_listener.py
+++ b/pytest_message/listeners/slack_listener.py
@@ -2,7 +2,7 @@ import dataclasses
 import datetime
 import os
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, List
+from typing import Any, List, Optional
 
 from _pytest.reports import TestReport
 from slack_sdk import WebClient, errors
@@ -35,10 +35,11 @@ class ErrReportMetadata:
 
 
 class SlackListener(Listener):
-    def __init__(self, token: str, chat: str):
+    def __init__(self, token: str, chat: str, *, on_error_add: Optional[str] = None):
         self.state = []
         self._client = self.configure(token)
         self._chat = chat
+        self._on_error_add = on_error_add
 
     @staticmethod
     def configure(token: str) -> WebClient:
@@ -62,7 +63,7 @@ class SlackListener(Listener):
             status, err = self._get_test_info(report)
             header = self._create_testfunc_header_block(status, func_name)
 
-            header_response = self._client.chat_postMessage(channel=self._chat, blocks=[header])
+            header_response = self._client.chat_postMessage(channel=self._chat, blocks=header)
             thread_ts = header_response.data['ts']
 
             err_blocks = self._prepare_err_report_block(report)
@@ -115,21 +116,36 @@ class SlackListener(Listener):
 
         return Status(total, passed, failed, skipped), errors
 
-    def _create_testfunc_header_block(self, status: Status, header) -> dict:
+    def _create_testfunc_header_block(self, status: Status, header) -> List[dict]:
 
-        return {
-            "type": "section",
-            "fields": [
-                {
-                    "type": "mrkdwn",
-                    "text": f"*{header}*"
-                },
-                {
-                    "type": "mrkdwn",
-                    "text": self._create_testfunc_status_msg(status)
-                }
-            ]
-        }
+        blocks = [
+            {
+                "type": "section",
+                "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*{header}*"
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": self._create_testfunc_status_msg(status)
+                    }
+                ]
+            }
+        ]
+        if status.failed or status.skipped:
+            blocks.append({
+                "type": "section",
+                "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*{self._on_error_add}*"
+                    }
+                ]
+
+            })
+
+        return blocks
 
     def _create_testfunc_status_msg(self, status: Status) -> str:
         if status.total == 1:

--- a/pytest_message/listeners/slack_listener.py
+++ b/pytest_message/listeners/slack_listener.py
@@ -133,7 +133,7 @@ class SlackListener(Listener):
                 ]
             }
         ]
-        if status.failed or status.skipped:
+        if self._on_error_add and (status.failed or status.skipped):
             blocks.append({
                 "type": "section",
                 "fields": [


### PR DESCRIPTION
Add optional custom comment field for SlackListener - `on_error_add`. 
If passed - add to failing or skipping message only